### PR TITLE
Improve I/O performance problems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tauri-apps/api": "^1.0.0-rc.5",
+        "codemirror": "^5.65.3",
         "sirv-cli": "^2.0.2",
         "svelte-frappe-charts": "^1.9.2"
       },
@@ -974,6 +975,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/codemirror": {
+      "version": "5.65.3",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.3.tgz",
+      "integrity": "sha512-kCC0iwGZOVZXHEKW3NDTObvM7pTIyowjty4BUqeREROc/3I6bWbgZDA3fGDwlA+rbgRjvnRnfqs9SfXynel1AQ=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -3574,6 +3580,11 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "codemirror": {
+      "version": "5.65.3",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.3.tgz",
+      "integrity": "sha512-kCC0iwGZOVZXHEKW3NDTObvM7pTIyowjty4BUqeREROc/3I6bWbgZDA3fGDwlA+rbgRjvnRnfqs9SfXynel1AQ=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^1.0.0-rc.5",
+    "codemirror": "^5.65.3",
     "sirv-cli": "^2.0.2",
     "svelte-frappe-charts": "^1.9.2"
   }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "app"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.8.0"
+version = "0.9.0"
 description = "Cross-platform prime number calculator developed on Tauri and Svelte with beautiful frappe graphs and excellent performance"
 authors = ["Doodles"]
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "graph-prime",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "tauri": {
     "allowlist": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -129,8 +129,8 @@
   }
 
   #primes {
-    max-height: 500px;
-    overflow: scroll;
+    /* Use the codemirror scroll for performance */
+    overflow: hidden;
   }
 
   #primes p {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,6 +2,7 @@
   import Chart from "svelte-frappe-charts";
   import { invoke } from "@tauri-apps/api/tauri";
   import { slide } from "svelte/transition";
+  import CodeMirror from "./CodeMirrorComponent.svelte";
   import "./progress.css";
 
   export let name: string;
@@ -28,6 +29,17 @@
       },
     ],
   };
+
+  // Codemirror options
+  $: options = {
+    mode: "markdown",
+    lineNumbers: false,
+    lineWrapping: true,
+    value: primes.join(", "),
+  };
+
+  // Reference to the CodeMirror instance
+  let editor;
 
   async function calculate() {
     // Start the timer and save the chosen final value
@@ -83,7 +95,7 @@
     <div id="primes" class="card">
       <h2>Primes</h2>
       <p>
-        {primes.join(", ")}
+        <CodeMirror bind:editor {options} class="editor" />
       </p>
     </div>
 

--- a/src/CodeMirrorComponent.svelte
+++ b/src/CodeMirrorComponent.svelte
@@ -1,0 +1,393 @@
+<!-- 
+    Adapted from https://svelte.dev/repl/a199ca2d451e4b0b92a8abd2d0e71ec6?version=3.35.0
+    As an alternative to @joshnuss/svelte-codemirror
+    Removed a lot of unnecessary code from the original example, specifically the styling
+ -->
+<script>
+  import { onMount } from "svelte";
+  import CodeMirror from "codemirror";
+
+  let classes = "";
+
+  export let editor = null;
+  export let options = {};
+  export { classes as class };
+
+  let element;
+
+  onMount(() => {
+    createEditor();
+  });
+
+  $: if (element) {
+    createEditor(options);
+  }
+
+  function createEditor(options) {
+    if (editor) element.innerHTML = "";
+    editor = CodeMirror(element, options);
+  }
+</script>
+
+<div bind:this={element} class={classes} />
+
+<style unscoped>
+  @media (prefers-color-scheme: light) {
+    :root {
+      --cm-border-color: #ccc;
+      --cm-background-color: white;
+      --cm-medium-color: #ccc;
+      --cm-text-color: #222;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --cm-border-color: #ccc;
+      --cm-background-color: #222;
+      --cm-medium-color: #ccc;
+      --cm-text-color: white;
+    }
+  }
+
+  /* BASICS */
+  :global(.CodeMirror) {
+    /* Set height, width, borders, and global font properties here */
+    font-family: monospace;
+    height: 300px;
+    direction: ltr;
+    color: var(--cm-text-color);
+    background: var(--cm-background-color);
+  }
+
+  /* CURSOR */
+
+  :global(.CodeMirror-cursor) {
+    border-left: 2px solid var(--cm-medium-color);
+    border-right: none;
+    width: 0;
+  }
+  /* Shown when moving in bi-directional text */
+  :global(.CodeMirror div.CodeMirror-secondarycursor) {
+    border-left: 1px solid var(--cm-medium-color);
+  }
+  :global(.cm-fat-cursor .CodeMirror-cursor) {
+    width: auto;
+    border: 0 !important;
+    background: var(--cursor-color);
+  }
+  :global(.cm-fat-cursor div.CodeMirror-cursors) {
+    z-index: 1;
+  }
+  :global(.cm-fat-cursor-mark) {
+    background-color: var(--cursor-color);
+    -webkit-animation: blink 1.06s steps(1) infinite;
+    -moz-animation: blink 1.06s steps(1) infinite;
+    animation: blink 1.06s steps(1) infinite;
+  }
+  :global(.cm-animate-fat-cursor) {
+    width: auto;
+    border: 0;
+    -webkit-animation: blink 1.06s steps(1) infinite;
+    -moz-animation: blink 1.06s steps(1) infinite;
+    animation: blink 1.06s steps(1) infinite;
+    background-color: var(--cursor-color);
+  }
+  @-moz-keyframes blink {
+    0% {
+    }
+    50% {
+      background-color: transparent;
+    }
+    100% {
+    }
+  }
+  @-webkit-keyframes blink {
+    0% {
+    }
+    50% {
+      background-color: transparent;
+    }
+    100% {
+    }
+  }
+  @keyframes blink {
+    0% {
+    }
+    50% {
+      background-color: transparent;
+    }
+    100% {
+    }
+  }
+
+  :global(.cm-tab) {
+    display: inline-block;
+    text-decoration: inherit;
+  }
+
+  /* Default styles for common addons */
+
+  :global(div.CodeMirror span.CodeMirror-matchingbracket) {
+    color: #0b0;
+  }
+  :global(div.CodeMirror span.CodeMirror-nonmatchingbracket) {
+    color: #a22;
+  }
+  :global(.CodeMirror-matchingtag) {
+    background: rgba(255, 150, 0, 0.3);
+  }
+  :global(.CodeMirror-activeline-background) {
+    background: #e8f2ff;
+  }
+
+  /* STOP */
+
+  /* The rest of this file contains styles related to the mechanics of
+     the editor. You probably shouldn't touch them. */
+
+  :global(.CodeMirror) {
+    position: relative;
+    overflow: hidden;
+  }
+
+  :global(.CodeMirror-scroll) {
+    overflow: scroll !important; /* Things will break if this is overridden */
+    /* 30px is the magic margin used to hide the element's real scrollbars */
+    /* See overflow: hidden in .CodeMirror */
+    margin-bottom: -30px;
+    margin-right: -30px;
+    padding-bottom: 30px;
+    height: 100%;
+    outline: none; /* Prevent dragging from highlighting the element */
+    position: relative;
+  }
+  :global(.CodeMirror-sizer) {
+    position: relative;
+    border-right: 30px solid transparent;
+  }
+
+  /* The fake, visible scrollbars. Used to force redraw during scrolling
+     before actual scrolling happens, thus preventing shaking and
+     flickering artifacts. */
+  :global(.CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler) {
+    position: absolute;
+    z-index: 6;
+    display: none;
+  }
+
+  :global(.CodeMirror ::-webkit-scrollbar) {
+    width: 8px;
+    height: 8px;
+  }
+
+  :global(.CodeMirror ::-webkit-scrollbar-track) {
+    background: #f4f4f4;
+    border-radius: 10px;
+  }
+
+  :global(.CodeMirror ::-webkit-scrollbar-thumb) {
+    border-radius: 10px;
+    background: var(--cm-medium-color);
+  }
+
+  :global(.CodeMirror-vscrollbar) {
+    right: 0;
+    top: 0;
+    overflow-x: hidden;
+    overflow-y: scroll;
+  }
+  :global(.CodeMirror-hscrollbar) {
+    bottom: 0;
+    left: 0;
+    overflow-y: hidden;
+    overflow-x: scroll;
+    height: 8px;
+  }
+  :global(.CodeMirror-scrollbar-filler) {
+    right: 0;
+    bottom: 0;
+  }
+  :global(.CodeMirror-gutter-filler) {
+    left: 0;
+    bottom: 0;
+  }
+
+  :global(.CodeMirror-gutters) {
+    position: absolute;
+    left: 0;
+    top: 0;
+    min-height: 100%;
+    z-index: 3;
+  }
+  :global(.CodeMirror-gutter) {
+    white-space: normal;
+    height: 100%;
+    display: inline-block;
+    vertical-align: top;
+    margin-bottom: -30px;
+  }
+  :global(.CodeMirror-gutter-wrapper) {
+    position: absolute;
+    z-index: 4;
+    background: none !important;
+    border: none !important;
+  }
+  :global(.CodeMirror-gutter-background) {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 4;
+  }
+  :global(.CodeMirror-gutter-elt) {
+    position: absolute;
+    cursor: default;
+    z-index: 4;
+  }
+  :global(.CodeMirror-gutter-wrapper ::selection) {
+    background-color: transparent;
+  }
+  :global(.CodeMirror-gutter-wrapper ::-moz-selection) {
+    background-color: transparent;
+  }
+
+  :global(.CodeMirror-lines) {
+    cursor: text;
+    min-height: 1px; /* prevents collapsing before first draw */
+  }
+  :global(.CodeMirror pre.CodeMirror-line, .CodeMirror
+      pre.CodeMirror-line-like) {
+    /* Reset some styles that the rest of the page might have set */
+    -moz-border-radius: 0;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    border-width: 0;
+    background: transparent;
+    font-family: inherit;
+    font-size: inherit;
+    margin: 0;
+    white-space: pre;
+    word-wrap: normal;
+    line-height: inherit;
+    color: inherit;
+    z-index: 2;
+    position: relative;
+    overflow: visible;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-font-variant-ligatures: contextual;
+    font-variant-ligatures: contextual;
+  }
+  :global(.CodeMirror-wrap pre.CodeMirror-line, .CodeMirror-wrap
+      pre.CodeMirror-line-like) {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    word-break: normal;
+  }
+
+  :global(.CodeMirror-linebackground) {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 0;
+  }
+
+  :global(.CodeMirror-linewidget) {
+    position: relative;
+    z-index: 2;
+    padding: 0.1px; /* Force widget margins to stay inside of the container */
+  }
+
+  :global(.CodeMirror-widget) {
+  }
+
+  :global(.CodeMirror-rtl pre) {
+    direction: rtl;
+  }
+
+  :global(.CodeMirror-code) {
+    outline: none;
+  }
+
+  /* Force content-box sizing for the elements where we expect it */
+  :global(.CodeMirror-scroll, .CodeMirror-sizer, .CodeMirror-gutter, .CodeMirror-gutters, .CodeMirror-linenumber) {
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+  }
+
+  :global(.CodeMirror-measure) {
+    position: absolute;
+    width: 100%;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+  }
+
+  :global(.CodeMirror-cursor) {
+    position: absolute;
+    pointer-events: none;
+  }
+  :global(.CodeMirror-measure pre) {
+    position: static;
+  }
+
+  :global(div.CodeMirror-cursors) {
+    /* always show cursor */
+    visibility: visible;
+    position: relative;
+    z-index: 3;
+  }
+  :global(div.CodeMirror-dragcursors) {
+    visibility: visible;
+  }
+
+  :global(.CodeMirror-focused div.CodeMirror-cursors) {
+    visibility: visible;
+  }
+
+  :global(.CodeMirror-selected) {
+    background: #d9d9d9;
+  }
+  :global(.CodeMirror-focused .CodeMirror-selected) {
+    background: #d7d4f0;
+  }
+  :global(.CodeMirror-crosshair) {
+    cursor: crosshair;
+  }
+  :global(.CodeMirror-line::selection, .CodeMirror-line
+      > span::selection, .CodeMirror-line > span > span::selection) {
+    background: #d7d4f0;
+  }
+  :global(.CodeMirror-line::-moz-selection, .CodeMirror-line
+      > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection) {
+    background: #d7d4f0;
+  }
+
+  :global(.cm-searching) {
+    background-color: #ffa;
+    background-color: rgba(255, 255, 0, 0.4);
+  }
+
+  /* Used to force a border model for a node */
+  :global(.cm-force-border) {
+    padding-right: 0.1px;
+  }
+
+  @media print {
+    /* Hide the cursor when printing */
+    :global(.CodeMirror div.CodeMirror-cursors) {
+      visibility: hidden;
+    }
+  }
+
+  /* See issue #2901 */
+  :global(.cm-tab-wrap-hack:after) {
+    content: "";
+  }
+
+  /* Help users use markselection to safely style text background */
+  :global(span.CodeMirror-selectedtext) {
+    background: none;
+  }
+</style>

--- a/src/CodeMirrorComponent.svelte
+++ b/src/CodeMirrorComponent.svelte
@@ -54,7 +54,7 @@
   :global(.CodeMirror) {
     /* Set height, width, borders, and global font properties here */
     font-family: monospace;
-    height: 300px;
+    height: auto;
     direction: ltr;
     color: var(--cm-text-color);
     background: var(--cm-background-color);
@@ -161,6 +161,8 @@
     height: 100%;
     outline: none; /* Prevent dragging from highlighting the element */
     position: relative;
+
+    max-height: 500px;
   }
   :global(.CodeMirror-sizer) {
     position: relative;

--- a/src/CodeMirrorComponent.svelte
+++ b/src/CodeMirrorComponent.svelte
@@ -162,6 +162,7 @@
     outline: none; /* Prevent dragging from highlighting the element */
     position: relative;
 
+    min-height: 40px;
     max-height: 500px;
   }
   :global(.CodeMirror-sizer) {


### PR DESCRIPTION
Implement CodeMirror as renderer for the huge prime text list allows primes rendered up to the finalValue 10.000.000 easilly WITHOUT DISPLAYING THE CHART, whereas previously even 1.000.000 would crash the application. Closes #6 