### PR TITLE
Disable chart generation with more than 10000 primes temporarilly

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "app"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.9.0"
+version = "0.10.0"
 description = "Cross-platform prime number calculator developed on Tauri and Svelte with beautiful frappe graphs and excellent performance"
 authors = ["Doodles"]
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "graph-prime",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "tauri": {
     "allowlist": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -101,7 +101,14 @@
 
     <div class="card">
       <h2>Graph</h2>
-      <Chart {data} type="line" />
+      {#if primes.length < 10000}
+        <Chart {data} type="line" />
+      {:else}
+        <p>
+          Chart generation disabled for more than 10000 prime numbers for
+          performance reasons
+        </p>
+      {/if}
     </div>
   {/if}
 </main>


### PR DESCRIPTION
This fixes the problem with repeated calculations. Closes #9 