### PR TITLE
Better chart performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tauri-apps/api": "^1.0.0-rc.5",
         "codemirror": "^5.65.3",
+        "dygraphs": "^2.1.0",
         "sirv-cli": "^2.0.2",
         "svelte-frappe-charts": "^1.9.2"
       },
@@ -1100,6 +1101,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dygraphs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dygraphs/-/dygraphs-2.1.0.tgz",
+      "integrity": "sha1-L7/SyAPq0CMH3z+vjU3T71XLIHU="
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
@@ -3679,6 +3685,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dygraphs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dygraphs/-/dygraphs-2.1.0.tgz",
+      "integrity": "sha1-L7/SyAPq0CMH3z+vjU3T71XLIHU="
     },
     "es6-promise": {
       "version": "3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
         "@rollup/plugin-typescript": "^8.0.0",
-        "@tauri-apps/cli": "^1.0.0-rc.10",
+        "@tauri-apps/cli": "^1.0.0-rc.11",
         "@tsconfig/svelte": "^2.0.0",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.24.0",
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.10.tgz",
-      "integrity": "sha512-njDei3F3mlnotnujUF0jWteZC39RCm6JNAxZpzTFvWKFI/650DoA9hHTMa6onbazVgmOWdrbMHYWU/xBC/jUTw==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.11.tgz",
+      "integrity": "sha512-tTrJiHa0rVyAh9IbuZ9hjEj02MetyoLKeWxQMl3fuDtl1+g1M7pjQqzS0aXLYMGmNYp/qAtj89IzsSpY1JJ9LA==",
       "dev": true,
       "bin": {
         "tauri": "tauri.js"
@@ -294,21 +294,21 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.10",
-        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.10",
-        "@tauri-apps/cli-win32-ia32-msvc": "1.0.0-rc.10",
-        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.10"
+        "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.11",
+        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.11",
+        "@tauri-apps/cli-win32-ia32-msvc": "1.0.0-rc.11",
+        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.11"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-KwnAAsR+H/U9NPF2P3UvZ0orfh/e8ng639GCvQoN/7b/EYzkLXYWGFd1sddTSSu8BM4OvIVXK1B86pn1xFohyg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-OiefgwvFmyo/sbZtOo+hYFFGUS5hP3QlAtwDw0AMtGGA6K2QIb8KzMog5hsNcqp8h4vOUJ/0vMy8KdPHRmc90A==",
       "cpu": [
         "arm64"
       ],
@@ -322,9 +322,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-xIH+UnZPofpx4n3aphu2SD45uPXtX3rlsI5aO0ANsDWN/esuAAwRnh+JR+NlmJXPKwy1BNz9pewczE5JO5BdqA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-BA8knn2YTMetiFQiJg60JFhkeA5oexIqCKjOShWNHB3ft0xMGyTfkEjSo/cFHa3ESw54eHP9twhUD/yoXQV0zw==",
       "cpu": [
         "x64"
       ],
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
-      "integrity": "sha512-j0cVDcP7MPyOh8mC6pTiOnsGgxMc4GFlQGBUvriRkWFCrUbZPbq1Pxt/eTcroVGsT/ItCXvnYd9jEQ+e50LI3A==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-w3W5L0yQIRpH+LKtMNeAGagcVPICHx7x/V9jbSkThdmvoiSIwPc++lyNqr8aQ57rGi947LkoKTARyNSVr87DOA==",
       "cpu": [
         "arm"
       ],
@@ -354,9 +354,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-usdftJI/Jx0Z6TK8YJaHp2BtcNlvHeIUOnh3SmThbbYzDSFDqEW2E/McbxEhJJ13FPLVMLiIZYPpH26gE3vQxw==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-r6ew6fc8M39zBvanh1gN7JeLWhuyQnp0cuTScd2RvH29gdqx0Ox++AvYd/reLYY9Fxpa8qATkyMbmK+rhwfXRg==",
       "cpu": [
         "arm64"
       ],
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-zsOhkc477mbe5wSkNuLv+D6RmQvDiaV8rHTaur+B/pxk9F0SrCYoO0Slf6x08bIiSkjyL/gN0PxnOBbEBA0u4A==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-2YXU53UK5AU/v5YFXs3/R0UGA2e+/gz8mMLDkKhH3r09g265ycxnkNgOBaEP2ul/rxLG3ZLDZFzDXx3n3pIzFQ==",
       "cpu": [
         "arm64"
       ],
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-ongWuhXieKwW+xaYPshw/59xYbZVH6JNw+KRb/054VFnfZe/ZDYbN86mCJIlegOq9WAkdc0XSm1EEDx3i9FYCg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-3yr4QeCQIKdMWxLGa9goBd59DbuFwrnDXJlbA9cYD11jftDdIfFLYJNYJVyoLk7lHhsPh8cVmfEHmEU1By+D7Q==",
       "cpu": [
         "x64"
       ],
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-3AXJEdhFlX/erLBXmBkRG+oWfFLMMaJALSnxvzerteSNWiaEzTngy9Mo1yeAT51FhvJ+dbYQv0BWvPPFRYzpTQ==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-JJhVo9XKPin5Pgwm2+/LiCEVTbdGoKJLemP1mu6BZhGh1zMG3+u0Yyqql8+ZfoEU5FinFTELFRhRo7UNaWSCbQ==",
       "cpu": [
         "x64"
       ],
@@ -418,9 +418,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-2SvSk9z51AfCsbch2fvX4GNo3s0b8TO/Kd9B6rDIZ7TUxwnGShJNup2+KGvBovKqFAPmgyrSbgyEMKhKc1B4iA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-uJn80LUCju2QXhVpchQkN3MlQHXD/4ZNJHMTHtLqiDu6BOifaCWBm7F/xVO1IuZDhs36K4zSOXdmDh684DQJ2w==",
       "cpu": [
         "ia32"
       ],
@@ -434,9 +434,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-mijSjeQGBGh6rvpkrqsSiTB4vwGprAXoDCmnIxliZ1Md4GgLMh8jzIug1UKAUmmIW1nOaQ9C9xu4wQXyoRqWHg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-f1yS++rZRkVfqcfkGUAgBAihzUBrQwJu+fPkrqu0LpVwfaGMPP58H1IqtLbLGvCTbL8vUekq15gmAMs51eHbtw==",
       "cpu": [
         "x64"
       ],
@@ -3160,82 +3160,82 @@
       }
     },
     "@tauri-apps/cli": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.10.tgz",
-      "integrity": "sha512-njDei3F3mlnotnujUF0jWteZC39RCm6JNAxZpzTFvWKFI/650DoA9hHTMa6onbazVgmOWdrbMHYWU/xBC/jUTw==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-1.0.0-rc.11.tgz",
+      "integrity": "sha512-tTrJiHa0rVyAh9IbuZ9hjEj02MetyoLKeWxQMl3fuDtl1+g1M7pjQqzS0aXLYMGmNYp/qAtj89IzsSpY1JJ9LA==",
       "dev": true,
       "requires": {
-        "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.10",
-        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.10",
-        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.10",
-        "@tauri-apps/cli-win32-ia32-msvc": "1.0.0-rc.10",
-        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.10"
+        "@tauri-apps/cli-darwin-arm64": "1.0.0-rc.11",
+        "@tauri-apps/cli-darwin-x64": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-arm64-gnu": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-arm64-musl": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-x64-gnu": "1.0.0-rc.11",
+        "@tauri-apps/cli-linux-x64-musl": "1.0.0-rc.11",
+        "@tauri-apps/cli-win32-ia32-msvc": "1.0.0-rc.11",
+        "@tauri-apps/cli-win32-x64-msvc": "1.0.0-rc.11"
       }
     },
     "@tauri-apps/cli-darwin-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-KwnAAsR+H/U9NPF2P3UvZ0orfh/e8ng639GCvQoN/7b/EYzkLXYWGFd1sddTSSu8BM4OvIVXK1B86pn1xFohyg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-OiefgwvFmyo/sbZtOo+hYFFGUS5hP3QlAtwDw0AMtGGA6K2QIb8KzMog5hsNcqp8h4vOUJ/0vMy8KdPHRmc90A==",
       "dev": true,
       "optional": true
     },
     "@tauri-apps/cli-darwin-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-xIH+UnZPofpx4n3aphu2SD45uPXtX3rlsI5aO0ANsDWN/esuAAwRnh+JR+NlmJXPKwy1BNz9pewczE5JO5BdqA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-BA8knn2YTMetiFQiJg60JFhkeA5oexIqCKjOShWNHB3ft0xMGyTfkEjSo/cFHa3ESw54eHP9twhUD/yoXQV0zw==",
       "dev": true,
       "optional": true
     },
     "@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
-      "integrity": "sha512-j0cVDcP7MPyOh8mC6pTiOnsGgxMc4GFlQGBUvriRkWFCrUbZPbq1Pxt/eTcroVGsT/ItCXvnYd9jEQ+e50LI3A==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-w3W5L0yQIRpH+LKtMNeAGagcVPICHx7x/V9jbSkThdmvoiSIwPc++lyNqr8aQ57rGi947LkoKTARyNSVr87DOA==",
       "dev": true,
       "optional": true
     },
     "@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-usdftJI/Jx0Z6TK8YJaHp2BtcNlvHeIUOnh3SmThbbYzDSFDqEW2E/McbxEhJJ13FPLVMLiIZYPpH26gE3vQxw==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-r6ew6fc8M39zBvanh1gN7JeLWhuyQnp0cuTScd2RvH29gdqx0Ox++AvYd/reLYY9Fxpa8qATkyMbmK+rhwfXRg==",
       "dev": true,
       "optional": true
     },
     "@tauri-apps/cli-linux-arm64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-zsOhkc477mbe5wSkNuLv+D6RmQvDiaV8rHTaur+B/pxk9F0SrCYoO0Slf6x08bIiSkjyL/gN0PxnOBbEBA0u4A==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-2YXU53UK5AU/v5YFXs3/R0UGA2e+/gz8mMLDkKhH3r09g265ycxnkNgOBaEP2ul/rxLG3ZLDZFzDXx3n3pIzFQ==",
       "dev": true,
       "optional": true
     },
     "@tauri-apps/cli-linux-x64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-ongWuhXieKwW+xaYPshw/59xYbZVH6JNw+KRb/054VFnfZe/ZDYbN86mCJIlegOq9WAkdc0XSm1EEDx3i9FYCg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-3yr4QeCQIKdMWxLGa9goBd59DbuFwrnDXJlbA9cYD11jftDdIfFLYJNYJVyoLk7lHhsPh8cVmfEHmEU1By+D7Q==",
       "dev": true,
       "optional": true
     },
     "@tauri-apps/cli-linux-x64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-3AXJEdhFlX/erLBXmBkRG+oWfFLMMaJALSnxvzerteSNWiaEzTngy9Mo1yeAT51FhvJ+dbYQv0BWvPPFRYzpTQ==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-JJhVo9XKPin5Pgwm2+/LiCEVTbdGoKJLemP1mu6BZhGh1zMG3+u0Yyqql8+ZfoEU5FinFTELFRhRo7UNaWSCbQ==",
       "dev": true,
       "optional": true
     },
     "@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-2SvSk9z51AfCsbch2fvX4GNo3s0b8TO/Kd9B6rDIZ7TUxwnGShJNup2+KGvBovKqFAPmgyrSbgyEMKhKc1B4iA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-uJn80LUCju2QXhVpchQkN3MlQHXD/4ZNJHMTHtLqiDu6BOifaCWBm7F/xVO1IuZDhs36K4zSOXdmDh684DQJ2w==",
       "dev": true,
       "optional": true
     },
     "@tauri-apps/cli-win32-x64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-mijSjeQGBGh6rvpkrqsSiTB4vwGprAXoDCmnIxliZ1Md4GgLMh8jzIug1UKAUmmIW1nOaQ9C9xu4wQXyoRqWHg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-f1yS++rZRkVfqcfkGUAgBAihzUBrQwJu+fPkrqu0LpVwfaGMPP58H1IqtLbLGvCTbL8vUekq15gmAMs51eHbtw==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-typescript": "^8.0.0",
-    "@tauri-apps/cli": "^1.0.0-rc.10",
+    "@tauri-apps/cli": "^1.0.0-rc.11",
     "@tsconfig/svelte": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.24.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@tauri-apps/api": "^1.0.0-rc.5",
     "codemirror": "^5.65.3",
+    "dygraphs": "^2.1.0",
     "sirv-cli": "^2.0.2",
     "svelte-frappe-charts": "^1.9.2"
   }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e068cb2806bbc15b439846dc16c5f89f8599f2c3e4d73d4449d38f9b2f0b6c5"
+checksum = "0aacacf4d96c24b2ad6eb8ee6df040e4f27b0d0b39a5710c30091baa830485db"
 dependencies = [
  "smallvec",
 ]
@@ -1112,7 +1112,7 @@ checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -1201,9 +1201,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -1279,9 +1279,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "lock_api"
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "loom"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eb735cf3c8ebac6cc3655c5da2f4a088b6a19133aa482471a21ba0eb5d83ab"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
 dependencies = [
  "cfg-if",
  "generator",
@@ -1587,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
 
 [[package]]
 name = "pango"
@@ -1888,11 +1888,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2016,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -2075,9 +2075,9 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "same-file"
@@ -2170,7 +2170,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -2371,13 +2371,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2399,7 +2399,7 @@ version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a45a1c4c9015217e12347f2a411b57ce2c4fc543913b14b6fe40483328e709"
 dependencies = [
- "cfg-expr 0.10.2",
+ "cfg-expr 0.10.3",
  "heck 0.4.0",
  "pkg-config",
  "toml",
@@ -2408,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd55783f88aafed0c5510ae540716455297f4f6df08f8114dc9fddc37d76ee3"
+checksum = "df895eb66ff23d1824055114d6fbdd2c297bf70ad85349a4adaee0f8b2a860d1"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -2472,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "1.0.0-rc.10"
+version = "1.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5ab16d343563684af482b1cb87acc515a1e359515b70c525c709372134c257"
+checksum = "a4c7350af2191f3b7a288cadd672a01fc47c8c3610f990fc5e9b78b9953e2e82"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2518,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "1.0.0-rc.8"
+version = "1.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f85528e1a51b1d79761f56a0af8fb639ffa282e6bb01b012cdd552673e45be6"
+checksum = "ae2a4dfb8e5d8a5a4325fda01e9ddf327db23115dce0f54a4a3f9e8f74341f28"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6273cb4ba4210d48cba182415dd8ed2f23b29f9f89801f77a09fcbb6a6d92b"
+checksum = "1d7f042dc907b65468e33495b9d48982dec21216f5b7e9281eb10214aa028a0f"
 dependencies = [
  "base64",
  "brotli",
@@ -2553,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d91657771bb36eca42d86afc80aa05e10f6b7328f8f40630e52c10ae84ddf3"
+checksum = "bd358b30472a20c70d861b579960da1aee95232e833f72628d5f8dacf9cb2bcc"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -2567,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b266b563439a4c300a524edc695541d72cb5ba55cd41f27adc6944c9c88d6e"
+checksum = "ffba4a1d7e3a5770253c7dff2dd16553ae7f04c0505ac728447083c2e9bf2d09"
 dependencies = [
  "gtk",
  "http",
@@ -2586,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a5558141be2d58e9f8071ed29d49ccf56076d0b12d40b6b21c6d3f6786b8d2"
+checksum = "b78338baa375a2c3f7746e91595ef2b33b09bc4714586cc6b4486fb718d98e33"
 dependencies = [
  "cocoa",
  "gtk",
@@ -2605,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2d8266063ac4d696560d4ff4e695c3c238d8d96ef1120d1eab9ba7482f59a3"
+checksum = "c41e14b545d79532743e1d279b9b8488babf35737fcc6cfcd9dbc5fde58919c9"
 dependencies = [
  "brotli",
  "ctor",
@@ -2815,6 +2815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2828,12 +2834,6 @@ name = "unicode-segmentation"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "app"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,12 +13,12 @@ rust-version = "1.57"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "1.0.0-rc.8", features = [] }
+tauri-build = { version = "1.0.0-rc.9", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.0.0-rc.9", features = [] }
+tauri = { version = "1.0.0-rc.11", features = [] }
 slow_primes = "0.1.14"
 
 [features]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.10.0"
+version = "0.11.0"
 description = "Cross-platform prime number calculator developed on Tauri and Svelte with beautiful frappe graphs and excellent performance"
 authors = ["Doodles"]
 license = "GPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "graph-prime",
-    "version": "0.10.0"
+    "version": "0.11.0"
   },
   "tauri": {
     "allowlist": {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -20,11 +20,22 @@
   let calculating = false;
   let calculationTime = 0;
   let compositeNumbers = 74; // Hardcoded value for the default prime numbers
+  let chartType = "frappe";
 
   // Chart data in csv format, recalculated on every change of primes
-  $: chartData = ["X,Y\n"]
+  $: csvChartData = ["X,Y\n"]
     .concat(primes.map((prime, i) => `${i},${prime}\n`))
     .join("");
+
+  // Chart data, recalculated on every change of primes
+  $: chartData = {
+    labels: [...Array(primes.length).keys()].map((i) => i + 1),
+    datasets: [
+      {
+        values: primes,
+      },
+    ],
+  };
 
   // Codemirror options
   $: options = {
@@ -97,10 +108,42 @@
       </p>
     </div>
 
-    <div class="card" style="height: 600px">
-      <h2>Graph</h2>
-      <DyGraphComponent bind:graph data={chartData} class="chart" />
-    </div>
+    {#if chartType === "frappe"}
+      <div class="card">
+        <select
+          name="Graph Types"
+          id="graphTypes"
+          style="position: absolute; left: 10px"
+          bind:value={chartType}
+        >
+          <option value="frappe">Basic</option>
+          <option value="dygraph">Scientific</option>
+        </select>
+        <h2>Graph</h2>
+        {#if primes.length < 10000}
+          <Chart data={chartData} type="line" />
+        {:else}
+          <p>
+            Basic chart is disabled for more than 10000 prime numbers for
+            performance reasons
+          </p>
+        {/if}
+      </div>
+    {:else}
+      <div class="card" style="height: 600px">
+        <select
+          name="Graph Types"
+          id="graphTypes"
+          style="position: absolute; left: 10px"
+          bind:value={chartType}
+        >
+          <option value="frappe">Basic</option>
+          <option value="dygraph">Scientific</option>
+        </select>
+        <h2>Graph</h2>
+        <DyGraphComponent bind:data={csvChartData} class="chart" />
+      </div>
+    {/if}
   {/if}
 </main>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -97,7 +97,7 @@
       </p>
     </div>
 
-    <div class="card">
+    <div class="card" style="height: 600px">
       <h2>Graph</h2>
       <DyGraphComponent bind:graph data={chartData} class="chart" />
     </div>
@@ -119,6 +119,7 @@
   }
 
   .card {
+    position: relative;
     /* Cast a nice shadow */
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
     border-radius: 5px;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -50,11 +50,16 @@
   let graph;
 
   async function calculate() {
-    // Start the timer and save the chosen final value
-    // Since finalValue updates on input and could change during the calculation
+    // Save because finalValue binds to input and may change during calculation
+    const chosenFinalValue = finalValue;
+
+    // Change chart to dygraph if we have too much data to prevent crashes
+    if (chosenFinalValue >= 10000) chartType = "dygraph";
+    else chartType = "frappe";
+
+    // Start the timer
     calculating = true;
     const calculationStart = Date.now();
-    const chosenFinalValue = finalValue;
 
     // Calculate primes upto finalValue
     primes = await invoke("calculate", { x: finalValue });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -57,7 +57,7 @@
 
 <main>
   <div class="card">
-    <h1>Welcome to {name}!</h1>
+    <h1 class="title">Welcome to {name}!</h1>
     <p>
       Use this application to generate prime sequences and graph them all within
       the comfort of your desktop.
@@ -66,11 +66,12 @@
     <input
       type="number"
       bind:value={finalValue}
+      class="input"
       min="0"
       max="100000"
       placeholder="100"
     />
-    <button on:click={calculate}>Calculate</button>
+    <button on:click={calculate} class="button">Calculate</button>
   </div>
 
   {#if calculating}
@@ -104,14 +105,7 @@
 </main>
 
 <style>
-  main {
-    text-align: center;
-    padding-bottom: 1em;
-    max-width: 240px;
-    margin: 0 auto;
-  }
-
-  h1 {
+  .title {
     color: #ff3e00;
     font-size: 3em;
     font-weight: 300;
@@ -138,7 +132,7 @@
     font-variant-numeric: tabular-nums;
   }
 
-  input {
+  .input {
     width: 70%;
     padding: 0.5em;
     margin-bottom: 1em;
@@ -148,7 +142,7 @@
     font-weight: 100;
     font-family: monospace;
   }
-  button {
+  .button {
     width: 20%;
     padding: 0.5em;
     margin-bottom: 1em;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,6 +3,7 @@
   import { invoke } from "@tauri-apps/api/tauri";
   import { slide } from "svelte/transition";
   import CodeMirror from "./CodeMirrorComponent.svelte";
+  import DyGraphComponent from "./DyGraphComponent.svelte";
   import "./progress.css";
 
   export let name: string;
@@ -20,15 +21,10 @@
   let calculationTime = 0;
   let compositeNumbers = 74; // Hardcoded value for the default prime numbers
 
-  // Chart data, recalculated on every change of primes
-  $: data = {
-    labels: [...Array(primes.length).keys()].map((i) => i + 1),
-    datasets: [
-      {
-        values: primes,
-      },
-    ],
-  };
+  // Chart data in csv format, recalculated on every change of primes
+  $: chartData = ["X,Y\n"]
+    .concat(primes.map((prime, i) => `${i},${prime}\n`))
+    .join("");
 
   // Codemirror options
   $: options = {
@@ -38,8 +34,9 @@
     value: primes.join(", "),
   };
 
-  // Reference to the CodeMirror instance
+  // References to the CodeMirror and DyGraph instances
   let editor;
+  let graph;
 
   async function calculate() {
     // Start the timer and save the chosen final value
@@ -101,14 +98,7 @@
 
     <div class="card">
       <h2>Graph</h2>
-      {#if primes.length < 10000}
-        <Chart {data} type="line" />
-      {:else}
-        <p>
-          Chart generation disabled for more than 10000 prime numbers for
-          performance reasons
-        </p>
-      {/if}
+      <DyGraphComponent bind:graph data={chartData} class="chart" />
     </div>
   {/if}
 </main>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -105,6 +105,13 @@
 </main>
 
 <style>
+  main {
+    text-align: center;
+    padding-bottom: 1em;
+    max-width: 240px;
+    margin: 0 auto;
+  }
+
   .title {
     color: #ff3e00;
     font-size: 3em;

--- a/src/DyGraphComponent.svelte
+++ b/src/DyGraphComponent.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { onMount } from "svelte";
+  import Dygraph from "dygraphs";
+  import "dygraph.css";
+
+  let classes = "";
+
+  export let graph = null;
+  export let data;
+  export { classes as class };
+
+  let element;
+
+  onMount(() => {
+    createGraph();
+  });
+
+  $: if (element && data) {
+    createGraph();
+  }
+
+  function createGraph() {
+    if (graph) element.innerHTML = "";
+    graph = new Dygraph(element, data, {});
+  }
+</script>
+
+<div bind:this={element} class={classes} />
+
+<style unscoped></style>

--- a/src/DyGraphComponent.svelte
+++ b/src/DyGraphComponent.svelte
@@ -27,4 +27,9 @@
 
 <div bind:this={element} class={classes} />
 
-<style unscoped></style>
+<style unscoped>
+  .chart {
+    position: absolute;
+    inset: 100px 10px 10px 10px;
+  }
+</style>


### PR DESCRIPTION
By implement DyGraphs as a possible graph render lib we can now render charts up to the millions with little to no impact on performance, although this update does not actually implement sampling, which is something that could be done with Apache ECharts or manually. Closes #8 